### PR TITLE
Make API for youtube.Client and youtube.CachingClient compatible.

### DIFF
--- a/test_youtube.py
+++ b/test_youtube.py
@@ -35,13 +35,22 @@ class TestCachingClient(unittest.TestCase):
     def test_get_channel_data(self):
         data = self.caching_client.get_channel_data('UCwYh0qBAF8HyKt0KUMp1rNg')
         self.assertIsNotNone(data)
+        self.assertIsNotNone(data['name'])
+        self.assertIsNotNone(data['videos'])
+        self.assertIsNotNone(data['playlists'])
+        self.assertIsNotNone(data['_raw'])
 
     def test_get_channel_data_twice(self):
         data = self.caching_client.get_channel_data('UCwYh0qBAF8HyKt0KUMp1rNg')
         self.assertIsNotNone(data)
         data = self.caching_client.get_channel_data('UCwYh0qBAF8HyKt0KUMp1rNg')
         self.assertIsNotNone(data)
+        self.assertIsNotNone(data['name'])
+        self.assertIsNotNone(data['videos'])
+        self.assertIsNotNone(data['playlists'])
+        self.assertIsNotNone(data['_raw'])
         stats = self.caching_client.stats()
+        self.assertLessEqual(stats['misses'], 1)
         self.assertGreaterEqual(stats['hits'], 2)
 
 if __name__ == '__main__':

--- a/youtube.py
+++ b/youtube.py
@@ -13,7 +13,7 @@ class CachingClient:
         return self._get(self._gen_playlist_cache_key, id, self.client.get_playlist_data, self._cache_playlist_parts)
 
     def get_channel_data(self, id):
-        return self._get(self._gen_channel_cache_key, id, self.client.get_channel_data, self._cache_channel_parts)
+        return self._get(self._gen_channel_cache_key, id, self.client.get_channel_data, None)
 
     def _get(self, cache_key_gen_func, id, get_func, further_caching_func):
         key = cache_key_gen_func(id)
@@ -25,9 +25,6 @@ class CachingClient:
                 further_caching_func(data)
         return data
 
-    def _cache_channel_parts(self, enriched_channel):
-        self._cache_playlist_parts(enriched_channel)
-
     def _cache_playlist_parts(self, enriched_playlist):
         playlist = enriched_playlist.get('_raw', {})
         assert playlist.get('_type', None) == 'playlist'
@@ -35,7 +32,7 @@ class CachingClient:
             self._cache_video(entry)
 
     def _cache_video(self, video):
-        self.cache.add(self._gen_video_cache_key(video['id'], video))
+        self.cache.add(self._gen_video_cache_key(video['id']), video)
         return video
 
     def _gen_playlist_cache_key(self, x):

--- a/youtube.py
+++ b/youtube.py
@@ -1,43 +1,51 @@
 import youtube_dl
+from collections import defaultdict
 
 class CachingClient:
     def __init__(self, client, cache):
         self.client = client
         self.cache = cache
 
-    # TODO: Use the underlying client subtitle configuration as part of the composite caching key,
-    # to do the caching very granular in regards to the kind of subtitle that the payload has
-    def get_video_data(self, id, subtitles=True):
-        return self._get(lambda x: f'video:{x}', id, self.client.get_video_data)
+    def get_video_data(self, id):
+        return self._get(self._gen_video_cache_key, id, self.client.get_video_data, self._cache_video)
 
     def get_playlist_data(self, id):
-        return self._get(lambda x: f'playlist:{x}', id, self.client.get_playlist_data, self._cache_videos)
+        return self._get(self._gen_playlist_cache_key, id, self.client.get_playlist_data, self._cache_playlist_parts)
 
-    # TODO: Possible add a playlist caching item for the channel as well (since it seems that every channel is a playlist)
     def get_channel_data(self, id):
-        return self._get(lambda x: f'channel:{x}', id, self.client.get_channel_data, self._cache_videos)
+        return self._get(self._gen_channel_cache_key, id, self.client.get_channel_data, self._cache_channel_parts)
 
-    def _get(self, cache_key_gen_func, id, get_func, post_process_func=None):
+    def _get(self, cache_key_gen_func, id, get_func, further_caching_func):
         key = cache_key_gen_func(id)
         found, data = self.cache.get(key)
         if not found:
             data = get_func(id)
-
-            # TODO: If we had an `etag` to control the version of the payload retrieved,
-            # it would give us better control to invalidate the cache
             self.cache.add(key, data)
-            if post_process_func:
-                post_process_func(data)(self.cache)
+            if further_caching_func:
+                further_caching_func(data)
         return data
 
-    def _cache_videos(self, playlist):
-        assert playlist['_type'] == 'playlist'
-        def wrapper(cache):
-            for entry in playlist.get('entries'):
-                cache.add(f"video:{entry['id']}", entry)
+    def _cache_channel_parts(self, enriched_channel):
+        self._cache_playlist_parts(enriched_channel)
 
-            # TODO: group by video's playlist_id and add those items
-        return wrapper
+    def _cache_playlist_parts(self, enriched_playlist):
+        playlist = enriched_playlist.get('_raw', {})
+        assert playlist.get('_type', None) == 'playlist'
+        for entry in playlist.get('entries'):
+            self._cache_video(entry)
+
+    def _cache_video(self, video):
+        self.cache.add(self._gen_video_cache_key(video['id'], video))
+        return video
+
+    def _gen_playlist_cache_key(self, x):
+        return f'playlist:{x}'
+
+    def _gen_channel_cache_key(self, x):
+        return f'channel:{x}'
+
+    def _gen_video_cache_key(self, x):
+        return f'video:{x}'
 
     def stats(self):
         return self.cache.stats()
@@ -46,15 +54,34 @@ class Client:
     def __init__(self, client):
         self.client = client
 
-    # TODO: what's the correct video URL to use?
-    def get_video_data(self, id, subtitles=True):
+    def _get(self, url):
+        return self.client.extract_info(url, download=False)
+
+    def get_video_data(self, id):
         return self._get(f'https://www.youtube.com/watch?v={id}')
 
     def get_playlist_data(self, id):
-        return self._get(f'https://www.youtube.com/playlist?list={id}')
+        playlist = self._get(f'https://www.youtube.com/playlist?list={id}')
+        assert playlist.get('_type', None) == 'playlist'
+        return dict(name=playlist['title'],
+                    videos=[entry['id'] for entry in playlist.get('entries')],
+                    _raw=playlist
+        )
 
     def get_channel_data(self, id):
-        return self._get(f'https://www.youtube.com/channel/{id}')
+        channel = self._get(f'https://www.youtube.com/channel/{id}')
+        assert channel.get('_type', None) == 'playlist'
+        entries = channel.get('entries')
+        name = channel['title']
+        videos = [entry['id'] for entry in entries]
+        return dict(name=name,
+                    videos=videos,
+                    playlists=[playlist_id for playlist_id in self._groupby(lambda x: x['playlist_id'], entries).keys()],
+                    _raw=channel
+        )
 
-    def _get(self, url):
-        return self.client.extract_info(url, download=False)
+    def _groupby(self, key, seq):
+        d = defaultdict(int)
+        for item in seq:
+            d[key(item)] += 1
+        return d


### PR DESCRIPTION
This change allows you to either use a non-caching client or the caching-client, and not having to change the client code since the API (both inputs and outputs) are compatible.

Add more tests.